### PR TITLE
add descriptions for embedded models in assets/README.txt

### DIFF
--- a/assets/README.txt
+++ b/assets/README.txt
@@ -8,7 +8,3 @@ model.glb -- Entire robot with hopper slide extended and no intake, shooter hood
 model_0.glb -- Shooter hood.
 model_1.glb -- Indexer brush.
 model_2.glb -- Full intake model.
-
-config:
-
-config.json -- Configuration file that contains details about robot and camera dimensions and positions.

--- a/assets/README.txt
+++ b/assets/README.txt
@@ -4,11 +4,11 @@ https://docs.advantagescope.org/more-features/custom-assets
 
 models:
 
-model.glb (63.4 MB) -- Entire robot with hopper slide extended and no intake, shooter hood, indexer brush, or electronics shield.
-model_0.glb (689.9 KB) -- Shooter hood.
-model_1.glb (193.5 KB) -- Indexer brush.
-model_2.glb (5.8 MB) -- Full intake model.
+model.glb -- Entire robot with hopper slide extended and no intake, shooter hood, indexer brush, or electronics shield.
+model_0.glb -- Shooter hood.
+model_1.glb -- Indexer brush.
+model_2.glb -- Full intake model.
 
 config:
 
-config.json (1.7 KB) -- Configuration file that contains details about robot and camera dimensions and positions.
+config.json -- Configuration file that contains details about robot and camera dimensions and positions.

--- a/assets/README.txt
+++ b/assets/README.txt
@@ -1,3 +1,14 @@
 This folder contains extra assets for the 2D field, 3D field, and joystick views. For more details, see the "Custom Fields/Robots/Joysticks" page in the AdvantageScope documentation (available through the documentation tab in the app or the URL below).
 
 https://docs.advantagescope.org/more-features/custom-assets
+
+models:
+
+model.glb (63.4 MB) -- Entire robot with hopper slide extended and no intake, shooter hood, indexer brush, or electronics shield.
+model_0.glb (689.9 KB) -- Shooter hood.
+model_1.glb (193.5 KB) -- Indexer brush.
+model_2.glb (5.8 MB) -- Full intake model.
+
+config:
+
+config.json (1.7 KB) -- Configuration file that contains details about robot and camera dimensions and positions.


### PR DESCRIPTION
the README.txt in assets contains a link to advantagescope documentation, but does not make it clear which robot models are what. The models have standardized names, this makes it difficult to determine where a subsystem is. This added documentation should help :)

I added descriptions of what the models actually are of.